### PR TITLE
Handle strncpy in a way compatible with gcc-9 linting

### DIFF
--- a/src/procenv.c
+++ b/src/procenv.c
@@ -4337,10 +4337,10 @@ format_time (const time_t *t, char *buffer, size_t len)
 		bug ("buffer too small");
 
 	/* Ensure nul byte copied */
-	strncpy (buffer, str, l+1);
+	strncpy (buffer, str, len);
 
 	/* Overwrite NL */
-	buffer[strlen (buffer)-1] = '\0';
+	buffer[strlen (str)-1] = '\0';
 }
 
 char *


### PR DESCRIPTION
gcc-9 is now more rigorous about ensuring strncpy() is used correctly and
errors out if the bound argument appears to be derived from the source
argument:
/usr/include/bits/string_fortified.h:106:10: error: '__builtin_strncpy' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
Leverage this compiler functionality, and in the process fix a possible
1-byte buffer overflow.