### PR TITLE
Fix GCC-10 build when used with -Werror=format-overflow= (Fixes #15)

### DIFF
--- a/src/platform/linux/platform.c
+++ b/src/platform/linux/platform.c
@@ -1263,12 +1263,12 @@ handle_proc_branch_linux (void)
 
 			if ((p=strstr (buffer, "Name:")) == buffer) {
 				p += 1+strlen ("Name:"); /* jump over tab char */
-				sprintf (name, "%s", p);
+				sprintf (name, "%.15s", p);
 			}
 
 			if ((p=strstr (buffer, "PPid:")) == buffer) {
 				p += 1+strlen ("PPid:"); /* jump over tab char */
-				sprintf (ppid, "%s", p);
+				sprintf (ppid, "%.15s", p);
 
 				/* got all we need now */
 				break;


### PR DESCRIPTION
Process names have a maximum length of 16 bytes and the buffer used has a
length of 16 bytes, but the compiler is picky about writing and arbirary
string into that small buffer. Tell the compiler to write max. 15 chars +
'\0', to make it happy.
https://stackoverflow.com/questions/23534263/what-is-the-maximum-allowed-limit-on-the-length-of-a-process-name