### PR TITLE
openbsd: fix comment in openbsd platform that refers to NetBSD

### DIFF
--- a/src/platform/openbsd/platform.c
+++ b/src/platform/openbsd/platform.c
@@ -178,7 +178,7 @@ handle_proc_branch_openbsd (void)
 /* XXX:Notes:
  *
  * - show_cpu : it doesn't appear you can query the CPU of the
- *   current process on NetBSD :-(
+ *   current process on OpenBSD :-(
  */
 struct procenv_ops platform_ops =
 {


### PR DESCRIPTION
The openbsd platform contains a comment that refers to NetBSD
and not OpenBSD. Fix it.

Signed-off-by: Colin Ian King <colin.king@canonical.com>