### PR TITLE
darwin: Don't assume '-flto' is available

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,7 @@ jobs:
         run: |
           sudo apt update -qq
           sudo apt install -y \
+            autoconf autoconf-archive \
             automake \
             autopoint \
             check \

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -20,6 +20,60 @@ You have another version of autoconf.  It may work, but is not guaranteed to.
 If you have problems, you may need to regenerate the build system entirely.
 To do so, use the procedure documented by the package, typically 'autoreconf'.])])
 
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS
+
 # pkg.m4 - Macros to locate and use pkg-config.   -*- Autoconf -*-
 # serial 12 (pkg-config-0.29.2)
 

--- a/configure
+++ b/configure
@@ -7115,6 +7115,98 @@ fi
 
 
 #---------------------------------------------------------------------
+# Platform-specifics
+
+# Magic options that will remove all unused symbols (defined by 'platform-generic.c').
+if test $procenv_platform = darwin
+then :
+  # Handle darwin
+
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -flto" >&5
+printf %s "checking whether C compiler accepts -flto... " >&6; }
+if test ${ax_cv_check_cflags___flto+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -flto"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___flto=yes
+else $as_nop
+  ax_cv_check_cflags___flto=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___flto" >&5
+printf "%s\n" "$ax_cv_check_cflags___flto" >&6; }
+if test "x$ax_cv_check_cflags___flto" = xyes
+then :
+  CFLAGS="$CFLAGS -flto"
+else $as_nop
+  :
+fi
+
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the linker accepts -flto" >&5
+printf %s "checking whether the linker accepts -flto... " >&6; }
+if test ${ax_cv_check_ldflags___flto+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS  -flto"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ax_cv_check_ldflags___flto=yes
+else $as_nop
+  ax_cv_check_ldflags___flto=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LDFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_ldflags___flto" >&5
+printf "%s\n" "$ax_cv_check_ldflags___flto" >&6; }
+if test "x$ax_cv_check_ldflags___flto" = xyes
+then :
+  LDFLAGS="$LDFLAGS -flto"
+else $as_nop
+  :
+fi
+
+
+else $as_nop
+  # Handle other platforms
+    CFLAGS="$CFLAGS -fdata-sections -ffunction-sections"; LDFLAGS="$LDFLAGS -Wl,--gc-sections"
+
+fi
+
+#---------------------------------------------------------------------
 # XXX: Dump details of the preprocess/compiler/linker *NOW* so that if
 # procenv fails to build later, the build logs will show details of the
 # environment that should aid remote debugging.

--- a/configure
+++ b/configure
@@ -7232,6 +7232,12 @@ sed 'h;s/./-/g;s/^.../## /;s/...$/ ##/;p;x;p;x' <<_ASBOX
 ## showing result of test '$t': $test_result ##
 _ASBOX
 
+# Strip leading space. Note the mandatory use of double quadrigraphs
+# to specify the character class to sed(1). We can't use literal
+# square brackets as autoconf(1)/m4(1) get upset.
+CFLAGS=$(echo "$CFLAGS" | sed 's/^[[:space:]]*//')
+LDFLAGS=$(echo "$LDFLAGS" | sed 's/^[[:space:]]*//')
+
 ac_config_files="$ac_config_files Makefile src/Makefile procenv.spec"
 
 cat >confcache <<\_ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,12 @@ AS_BOX($msg)
 AS_IF([$t], [test_result=pass], [test_result=fail])
 AS_BOX([showing result of test '$t': $test_result])
 
+# Strip leading space. Note the mandatory use of double quadrigraphs
+# to specify the character class to sed(1). We can't use literal
+# square brackets as autoconf(1)/m4(1) get upset.
+CFLAGS=$(echo "$CFLAGS" | sed 's/^@<:@@<:@:space:@:>@@:>@*//')
+LDFLAGS=$(echo "$LDFLAGS" | sed 's/^@<:@@<:@:space:@:>@@:>@*//')
+
 AC_CONFIG_FILES([Makefile src/Makefile procenv.spec])
 AC_OUTPUT
 AC_MSG_RESULT([

--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,21 @@ AM_CONDITIONAL([PROCENV_PLATFORM_GENERIC], [test "$procenv_platform" = unknown])
 AC_SUBST([procenv_platform])
 
 #---------------------------------------------------------------------
+# Platform-specifics
+
+# Magic options that will remove all unused symbols (defined by 'platform-generic.c').
+AS_IF(
+    [test $procenv_platform = darwin],
+    # Handle darwin
+    [
+        AX_CHECK_COMPILE_FLAG([-flto], [CFLAGS="$CFLAGS -flto"])
+        AX_CHECK_LINK_FLAG([-flto], [LDFLAGS="$LDFLAGS -flto"])
+    ],
+    # Handle other platforms
+    [CFLAGS="$CFLAGS -fdata-sections -ffunction-sections"; LDFLAGS="$LDFLAGS -Wl,--gc-sections"]
+)
+
+#---------------------------------------------------------------------
 # XXX: Dump details of the preprocess/compiler/linker *NOW* so that if
 # procenv fails to build later, the build logs will show details of the
 # environment that should aid remote debugging.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,14 +12,6 @@ AM_CFLAGS = \
 	-Wall -Wunused
 
 
-# XXX: magic option that will remove all unused symbols
-# (defined by platform-generic.c).
-if PROCENV_PLATFORM_DARWIN
-AM_CFLAGS += -flto
-else
-AM_CFLAGS += -fdata-sections -ffunction-sections
-endif
-
 # keep it tight
 AM_CFLAGS += -Werror
 
@@ -36,13 +28,6 @@ procenv_SOURCES = \
 	messages.h \
 	platform.h platform-headers.h \
     platform/platform-generic.c platform/platform-generic.h
-
-# XXX: unused symbol removal magic - part 2
-if PROCENV_PLATFORM_DARWIN
-procenv_LDFLAGS = -flto
-else
-procenv_LDFLAGS = -Wl,--gc-sections
-endif
 
 # should really do this in configure.ac
 if PROCENV_PLATFORM_MINIX

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -95,44 +95,39 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 target_triplet = @target@
-
-# XXX: magic option that will remove all unused symbols
-# (defined by platform-generic.c).
-@PROCENV_PLATFORM_DARWIN_TRUE@am__append_1 = -flto
-@PROCENV_PLATFORM_DARWIN_FALSE@am__append_2 = -fdata-sections -ffunction-sections
 bin_PROGRAMS = procenv$(EXEEXT)
-@PROCENV_PLATFORM_DARWIN_TRUE@am__append_3 = platform/darwin/platform.c platform/darwin/platform-darwin.h
-@PROCENV_PLATFORM_DARWIN_TRUE@am__append_4 = -I $(srcdir)/platform/darwin -D PROCENV_PLATFORM_DARWIN
-@PROCENV_PLATFORM_LINUX_TRUE@am__append_5 = platform/linux/platform.c platform/linux/platform-linux.h
-@PROCENV_PLATFORM_LINUX_TRUE@am__append_6 = -I $(srcdir)/platform/linux -D PROCENV_PLATFORM_LINUX
-@PROCENV_PLATFORM_MINIX_TRUE@am__append_7 = platform/minix/platform.c platform/minix/platform-minix.h
-@PROCENV_PLATFORM_MINIX_TRUE@am__append_8 = \
+@PROCENV_PLATFORM_DARWIN_TRUE@am__append_1 = platform/darwin/platform.c platform/darwin/platform-darwin.h
+@PROCENV_PLATFORM_DARWIN_TRUE@am__append_2 = -I $(srcdir)/platform/darwin -D PROCENV_PLATFORM_DARWIN
+@PROCENV_PLATFORM_LINUX_TRUE@am__append_3 = platform/linux/platform.c platform/linux/platform-linux.h
+@PROCENV_PLATFORM_LINUX_TRUE@am__append_4 = -I $(srcdir)/platform/linux -D PROCENV_PLATFORM_LINUX
+@PROCENV_PLATFORM_MINIX_TRUE@am__append_5 = platform/minix/platform.c platform/minix/platform-minix.h
+@PROCENV_PLATFORM_MINIX_TRUE@am__append_6 = \
 @PROCENV_PLATFORM_MINIX_TRUE@	-I $(srcdir)/platform/minix -D PROCENV_PLATFORM_MINIX
 
-@PROCENV_PLATFORM_HURD_TRUE@am__append_9 = platform/hurd/platform.c platform/hurd/platform-hurd.h
-@PROCENV_PLATFORM_HURD_TRUE@am__append_10 = -I $(srcdir)/platform/hurd -D PROCENV_PLATFORM_HURD
-@PROCENV_PLATFORM_FREEBSD_TRUE@am__append_11 = platform/freebsd/platform.c platform/freebsd/platform-freebsd.h
-@PROCENV_PLATFORM_FREEBSD_TRUE@am__append_12 = -I $(srcdir)/platform/freebsd \
+@PROCENV_PLATFORM_HURD_TRUE@am__append_7 = platform/hurd/platform.c platform/hurd/platform-hurd.h
+@PROCENV_PLATFORM_HURD_TRUE@am__append_8 = -I $(srcdir)/platform/hurd -D PROCENV_PLATFORM_HURD
+@PROCENV_PLATFORM_FREEBSD_TRUE@am__append_9 = platform/freebsd/platform.c platform/freebsd/platform-freebsd.h
+@PROCENV_PLATFORM_FREEBSD_TRUE@am__append_10 = -I $(srcdir)/platform/freebsd \
 @PROCENV_PLATFORM_FREEBSD_TRUE@				-D PROCENV_PLATFORM_FREEBSD \
 @PROCENV_PLATFORM_FREEBSD_TRUE@				-D PROCENV_PLATFORM_BSD
 
-@PROCENV_PLATFORM_NETBSD_TRUE@am__append_13 = platform/netbsd/platform.c platform/netbsd/platform-netbsd.h
-@PROCENV_PLATFORM_NETBSD_TRUE@am__append_14 = -I $(srcdir)/platform/netbsd \
+@PROCENV_PLATFORM_NETBSD_TRUE@am__append_11 = platform/netbsd/platform.c platform/netbsd/platform-netbsd.h
+@PROCENV_PLATFORM_NETBSD_TRUE@am__append_12 = -I $(srcdir)/platform/netbsd \
 @PROCENV_PLATFORM_NETBSD_TRUE@				-D PROCENV_PLATFORM_NETBSD \
 @PROCENV_PLATFORM_NETBSD_TRUE@				-D PROCENV_PLATFORM_BSD
 
-@PROCENV_PLATFORM_OPENBSD_TRUE@am__append_15 = platform/openbsd/platform.c platform/openbsd/platform-openbsd.h
-@PROCENV_PLATFORM_OPENBSD_TRUE@am__append_16 = -I $(srcdir)/platform/openbsd \
+@PROCENV_PLATFORM_OPENBSD_TRUE@am__append_13 = platform/openbsd/platform.c platform/openbsd/platform-openbsd.h
+@PROCENV_PLATFORM_OPENBSD_TRUE@am__append_14 = -I $(srcdir)/platform/openbsd \
 @PROCENV_PLATFORM_OPENBSD_TRUE@				-D PROCENV_PLATFORM_OPENBSD \
 @PROCENV_PLATFORM_OPENBSD_TRUE@				-D PROCENV_PLATFORM_BSD
 
-@PROCENV_PLATFORM_GENERIC_TRUE@am__append_17 = platform/unknown/platform.c platform/unknown/platform-unknown.h
-@PROCENV_PLATFORM_GENERIC_TRUE@am__append_18 = -I $(srcdir)/platform/unknown -D PROCENV_PLATFORM_GENERIC
-@HAVE_SELINUX_TRUE@am__append_19 = -DHAVE_SELINUX
-@HAVE_APPARMOR_TRUE@am__append_20 = -DHAVE_APPARMOR
+@PROCENV_PLATFORM_GENERIC_TRUE@am__append_15 = platform/unknown/platform.c platform/unknown/platform-unknown.h
+@PROCENV_PLATFORM_GENERIC_TRUE@am__append_16 = -I $(srcdir)/platform/unknown -D PROCENV_PLATFORM_GENERIC
+@HAVE_SELINUX_TRUE@am__append_17 = -DHAVE_SELINUX
+@HAVE_APPARMOR_TRUE@am__append_18 = -DHAVE_APPARMOR
 @ENABLE_TESTS_TRUE@TESTS = tests/show_machine_details $(am__EXEEXT_1) \
 @ENABLE_TESTS_TRUE@	check_all_args procenv$(EXEEXT)
-@ENABLE_TESTS_TRUE@@HAVE_CHECK_TRUE@am__append_21 = check_pr_list
+@ENABLE_TESTS_TRUE@@HAVE_CHECK_TRUE@am__append_19 = check_pr_list
 @ENABLE_TESTS_TRUE@@HAVE_CHECK_TRUE@check_PROGRAMS =  \
 @ENABLE_TESTS_TRUE@@HAVE_CHECK_TRUE@	check_pr_list$(EXEEXT)
 subdir = src
@@ -188,8 +183,6 @@ am_procenv_OBJECTS = procenv-procenv.$(OBJEXT) \
 	$(am__objects_8)
 procenv_OBJECTS = $(am_procenv_OBJECTS)
 procenv_DEPENDENCIES =
-procenv_LINK = $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(procenv_LDFLAGS) \
-	$(LDFLAGS) -o $@
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -397,26 +390,21 @@ top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = subdir-objects
 
 # keep it tight
-AM_CFLAGS = -pedantic -std=gnu99 -Wall -Wunused $(am__append_1) \
-	$(am__append_2) -Werror
+AM_CFLAGS = -pedantic -std=gnu99 -Wall -Wunused -Werror
 procenv_SOURCES = procenv.c procenv.h pr_list.c pr_list.h pstring.c \
 	pstring.h string-util.c string-util.h output.c output.h util.c \
 	util.h types.h messages.h platform.h platform-headers.h \
 	platform/platform-generic.c platform/platform-generic.h \
-	$(am__append_3) $(am__append_5) $(am__append_7) \
-	$(am__append_9) $(am__append_11) $(am__append_13) \
-	$(am__append_15) $(am__append_17)
-@PROCENV_PLATFORM_DARWIN_FALSE@procenv_LDFLAGS = -Wl,--gc-sections
-
-# XXX: unused symbol removal magic - part 2
-@PROCENV_PLATFORM_DARWIN_TRUE@procenv_LDFLAGS = -flto
+	$(am__append_1) $(am__append_3) $(am__append_5) \
+	$(am__append_7) $(am__append_9) $(am__append_11) \
+	$(am__append_13) $(am__append_15)
 
 # should really do this in configure.ac
 @PROCENV_PLATFORM_MINIX_TRUE@procenv_LDADD = -lc
-procenv_CPPFLAGS = -I $(srcdir) -I $(srcdir)/platform $(am__append_4) \
-	$(am__append_6) $(am__append_8) $(am__append_10) \
-	$(am__append_12) $(am__append_14) $(am__append_16) \
-	$(am__append_18) $(am__append_19) $(am__append_20)
+procenv_CPPFLAGS = -I $(srcdir) -I $(srcdir)/platform $(am__append_2) \
+	$(am__append_4) $(am__append_6) $(am__append_8) \
+	$(am__append_10) $(am__append_12) $(am__append_14) \
+	$(am__append_16) $(am__append_17) $(am__append_18)
 @ENABLE_TESTS_TRUE@CLEANFILES = check_all_args
 @ENABLE_TESTS_TRUE@@HAVE_CHECK_TRUE@check_pr_list_SOURCES = tests/check_pr_list.c pr_list.c
 @ENABLE_TESTS_TRUE@@HAVE_CHECK_TRUE@check_pr_list_CFLAGS = @CHECK_CFLAGS@ -I$(top_srcdir)/src
@@ -600,7 +588,7 @@ platform/unknown/procenv-platform.$(OBJEXT):  \
 
 procenv$(EXEEXT): $(procenv_OBJECTS) $(procenv_DEPENDENCIES) $(EXTRA_procenv_DEPENDENCIES) 
 	@rm -f procenv$(EXEEXT)
-	$(AM_V_CCLD)$(procenv_LINK) $(procenv_OBJECTS) $(procenv_LDADD) $(LIBS)
+	$(AM_V_CCLD)$(LINK) $(procenv_OBJECTS) $(procenv_LDADD) $(LIBS)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)


### PR DESCRIPTION
Move the symbol removal logic (`-flto` on darwin) to `configure.ac`.

Note the addition of `autoconf-archive` to the GH actions config
which is required for the autoconf `AS_IF()` macro.

Fixes: #28.

Signed-off-by: James O. D. Hunt <jamesodhunt@gmail.com>