### PR TITLE
cleanup: Remove duplicated perms code

### DIFF
--- a/src/platform/linux/platform.c
+++ b/src/platform/linux/platform.c
@@ -586,13 +586,6 @@ show_fds_linux (void)
 				die("failed to allocate space for permissions string");
 			perms = (st.st_mode & ~S_IFMT);
 
-			if (perms & S_ISUID)
-				modestr[3] = 's';
-			if (perms & S_ISGID)
-				modestr[6] = 's';
-			if (perms & S_ISVTX)
-				modestr[9] = 't';
-
 			section_open("permissions");
 
 			entry("octal", "%4.4o", perms);

--- a/src/procenv.c
+++ b/src/procenv.c
@@ -1920,13 +1920,6 @@ show_stat (void)
 		die ("failed to allocate space for permissions string");
 	perms = (st.st_mode & ~S_IFMT);
 
-	if (perms & S_ISUID)
-		modestr[3] = 's';
-	if (perms & S_ISGID)
-		modestr[6] = 's';
-	if (perms & S_ISVTX)
-		modestr[9] = 't';
-
 	section_open ("permissions");
 
 	entry ("octal", "%4.4o", perms);


### PR DESCRIPTION
Remove the redundant duplicated permissions handling code in `show_fds_linux()` and `show_stat()` after calling `format_perms()` since that function handles the logic itself.